### PR TITLE
Avoid using 'use ok' in test

### DIFF
--- a/t/live.t
+++ b/t/live.t
@@ -3,12 +3,12 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 8;
 
 use Template;
 use JSON;
 
-use ok 'Template::Plugin::JSON';
+use Template::Plugin::JSON;
 
 ok( Template->new->process(
 	\qq{[% USE JSON ( pretty => 1 ) %]{ "blah":[% blah.json %], "baz":[% baz.json %], "oink":[% oink.json %] }},


### PR DESCRIPTION
RT #128679

ok.pm is not provided with old versions of Test::Simple.
This was introduced in 1.001010.

Rather than requesting a specific version of Test::Simple
be friendly and let the test passes even when using an outdated
version of Test::Simple.

'use ok' does not provide much more value, the test would fail just
after if we cannot load the module.